### PR TITLE
fix #128: Add a permission request

### DIFF
--- a/app/src/main/java/com/pbm/PinballMapActivity.java
+++ b/app/src/main/java/com/pbm/PinballMapActivity.java
@@ -6,10 +6,12 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.SearchView.OnQueryTextListener;
@@ -381,6 +383,10 @@ public class PinballMapActivity extends AppCompatActivity implements OnQueryText
 			locationRequest.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
 			locationRequest.setInterval(60000 * 60);
 			locationRequest.setFastestInterval(60000);
+		}
+		if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+			// TODO refactor into something more useful
+			throw new IllegalStateException();
 		}
 		setLocation(LocationServices.FusedLocationApi.getLastLocation(googleApiClient));
 		LocationServices.FusedLocationApi.requestLocationUpdates(googleApiClient, locationRequest, this);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,5 @@
         <p>If you like Pinball Map and want to help support it, you have our heartfelt thanks! - Scott and Ryan</p>
     ]]></string>
     <string name="none_yet">None yet</string>
+    <string name="please_allow_location_permission">Please enable the Location permission inside the settings</string>
 </resources>


### PR DESCRIPTION
I've added a (very basic) permission request into the Login Activity (as it is the first one the user sees after the splash). It forces the user to give the fine location permission, however it is just a start. The user might, for example, click between the repeated permission requests while denying and get to another activity by pressing a button. Inside the activity, where the location is utilized, the location permission should already be granted, otherwise an exception is thrown.
